### PR TITLE
Add optional fat / shadow jar to build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "bisq"]
 	path = bisq
 	url = https://github.com/bisq-network/bisq.git
+	branch = master
 [submodule "bisq-gradle"]
 	path = bisq-gradle
 	url = https://github.com/bisq-network/bisq-gradle.git
+	branch = main

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'bisq.post-build'
+    alias(libs.plugins.shadow)
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ junit-jupiter-lib = { strictly = '5.8.2' }
 logback-lib = { strictly = '1.2.6' }
 lombok-lib = { strictly = '1.18.22' }
 slf4j-lib = { strictly = '1.7.36' }
+shadow-plugin = { strictly = '5.2.0' }
 spark-lib = { strictly = '2.5.2' }
 
 # Referenced in subproject's build.gradle > dependencies block in the form 'implementation libs.guava'
@@ -28,4 +29,4 @@ spark-core = { module = 'com.sparkjava:spark-core', version.ref = 'spark-lib' }
 [bundles]
 
 [plugins]
-
+shadow = { id = 'com.github.johnrengelman.shadow', version.ref = 'shadow-plugin' }


### PR DESCRIPTION
If the original bisq/inventory subproject build created a fat jar, this build should too.

Also set the git submodule branches bisq::master, bisq-gradle::main.